### PR TITLE
Slightly stricter `formula(<character>)` in R-devel {and possibly R 3.6.0}

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ordinal
 Type: Package
 Title: Regression Models for Ordinal Data
-Version: 2019.3-9
-Date: 2019-03-09
+Version: 2019.4-25
+Date: 2019-04-25
 Authors@R: person(given="Rune Haubo Bojesen", family="Christensen",
     email="rune.haubo@gmail.com", role=c("aut", "cre"))
 LazyData: true

--- a/NEWS
+++ b/NEWS
@@ -265,3 +265,7 @@ March 04 2010:
 
 2019-03-09:
 - Massage tests to check out on R-devel
+
+2019-04-25:
+- Change in formula evaluation in base R prompts this update - very kindly 
+  fixed by Martin Maechler (R core) in PR#18 

--- a/R/clmm.R
+++ b/R/clmm.R
@@ -1,5 +1,5 @@
 #############################################################################
-#    Copyright (c) 2010-2018 Rune Haubo Bojesen Christensen
+#    Copyright (c) 2010-2019 Rune Haubo Bojesen Christensen
 #
 #    This file is part of the ordinal package for R (*ordinal*)
 #
@@ -141,9 +141,10 @@ clmm.formulae <- function(formula) {
         if(!is.null(env <- environment(form))) env
         else parent.frame(2)
     ## ensure 'formula' is a formula-object:
-    form <- try(formula(deparse(form), env = form.envir), silent=TRUE)
+    form <- tryCatch(formula(if(is.character(form)) form else deparse(form),
+                             env = form.envir), error = identity)
     ## report error if the formula cannot be interpreted
-    if(class(form) == "try-error")
+    if(inherits(form, "error"))
         stop("unable to interpret 'formula'")
     environment(form) <- form.envir
     ## Construct a formula with all (fixed and random) variables
@@ -217,7 +218,7 @@ getREterms <- function(frames, formula) {
 ### NOTE: make sure 'formula' is appropriately evaluated and returned
 ### by clmm.formulae
     if(!length(barlist)) stop("No random effects terms specified in formula")
-    term.names <- unlist(lapply(barlist, function(x) deparse(x)))
+    term.names <- unlist(lapply(barlist, deparse))
     names(barlist) <- unlist(lapply(barlist, function(x) deparse(x[[3]])))
 ### NOTE: Deliberately naming the barlist elements by grouping factors
 ### and not by r.e. terms.


### PR DESCRIPTION
As  https://cloud.r-project.org/web/checks/check_results_ordinal.html  shows, ordinal is currently not passing its checks with "R-devel" .. by a change to the  `formula.character()` method (by myself as R Core member).

The reason is that is has been using the equivalent of
```r
 formula(" \" ~term \"  ")
```
-- note the __inner__ extra `".."` --  which "interestingly" has worked in R ... but no longer will in the future.

This PR effectuates changes to the `clm_*` and `clmm_*` formula "getting" functions, such that they work correctly in old and new R.  

Note that the extra `" .. "` happen because in your functions on getting the formula you call `deparse()` in addition to `formula()` etc.  This is not done by `lm()`, e.g.,  and it (and similar R functions) have not seen any change in behavior because of the more strict `formula(<character>)` method in future versions of R.
Note that specifically, `lmer()` from package `lme4` continues to work with all versions of formula specification:

```r
## Show that  lmer() can deal with  "character" or proper formula  and does
## even better than lm() to give the correct 'call' !!
require(lme4)

(fm1  <- lmer( Reaction ~ Days + (Days | Subject),  sleepstudy))
(fm1. <- lmer("Reaction ~ Days + (Days | Subject)", sleepstudy))
chf <- "Reaction ~ Days + (Days | Subject)"; (fm1.2 <- lmer(chf, sleepstudy))
fff <-  Reaction ~ Days + (Days | Subject) ; (fm1.3 <- lmer(fff, sleepstudy))
stopifnot(exprs = {
    all.equal(fm1, fm1. , tolerance=0)
    all.equal(fm1, fm1.2, tolerance=0)
    all.equal(fm1, fm1.3, tolerance=0)
})
```
