### PR TITLE
handle long random effects terms that exceed the width.cutoff of depa…

### DIFF
--- a/R/clmm.R
+++ b/R/clmm.R
@@ -218,7 +218,7 @@ getREterms <- function(frames, formula) {
 ### NOTE: make sure 'formula' is appropriately evaluated and returned
 ### by clmm.formulae
     if(!length(barlist)) stop("No random effects terms specified in formula")
-    term.names <- unlist(lapply(barlist, deparse))
+    term.names <- unlist(lapply(barlist, function(x) paste(deparse(x), collapse="")))
     names(barlist) <- unlist(lapply(barlist, function(x) deparse(x[[3]])))
 ### NOTE: Deliberately naming the barlist elements by grouping factors
 ### and not by r.e. terms.


### PR DESCRIPTION
`clmm()` can fail to process random effect terms if they exceed `width.cutoff` of `deparse()` (see issue #13). This is fixed by having `paste()` rejoin terms that are line-broken.